### PR TITLE
Simpler way of calculating the covariance matrix of a cluster

### DIFF
--- a/io/CubeReconCluster.cxx
+++ b/io/CubeReconCluster.cxx
@@ -147,117 +147,154 @@ void Cube::ReconCluster::UpdateFromHits() {
     if (!hits) return;
 
     // Make sure the hit container isn't empty.
-    Cube::HitSelection::const_iterator begin = hits->begin();
+    Cube::HitSelection::const_iterator beg = hits->begin();
     Cube::HitSelection::const_iterator end = hits->end();
-    if (end - begin < 1) return;
+    if (end-beg < 1) return;
 
     fStatus = Cube::ReconObject::kSuccess;
     fQuality = 1.0;
-    fNDOF = std::max(1,int(end - begin - 1));
+    fNDOF = std::max(1,int(end-beg-1));
     Cube::Handle<Cube::ClusterState> state = GetState();
 
     int dim = state->GetDimensions();
-    TVectorT<double> values(dim);
-    TVectorT<double> sigmas(dim);
+    TVectorT<double> vals(dim);
+    TVectorT<double> sigs(dim);
+    TVectorT<double> rms(dim);
 
     // Save the index into the state for each of the values.
-    int idxE = state->GetEDepositIndex();
-    int idxX = state->GetXIndex();
-    int idxY = state->GetYIndex();
-    int idxZ = state->GetZIndex();
-    int idxT = state->GetTIndex();
+    int eDep = state->GetEDepositIndex();
+    int posX = state->GetXIndex();
+    int posY = state->GetYIndex();
+    int posZ = state->GetZIndex();
+    int posT = state->GetTIndex();
 
-    // Calculate the weighted mean of the energy deposit, time and position.
-    // The stateWeights are chosen as the inverts of the square of the variance
+    // Find the energy deposit and the average position.
     TVectorT<double> stateValues(dim);
     TVectorT<double> stateNorms(dim);
-    for (auto hit = begin; hit != end; ++hit) {
-      values(idxE) = (*hit)->GetCharge();
-      sigmas(idxE) = 1.; // use unit weight for the charge
+    for (Cube::HitSelection::const_iterator h = beg;
+         h != end;
+         ++h) {
+        vals(eDep) = (*h)->GetCharge();
+        sigs(eDep) = 1.0;
 
-      values(idxX) = (*hit)->GetPosition().X();
-      sigmas(idxX) = (*hit)->GetUncertainty().X();
+        vals(posX) = (*h)->GetPosition().X();
+        sigs(posX) = (*h)->GetUncertainty().X();
 
-      values(idxY) = (*hit)->GetPosition().Y();
-      sigmas(idxY) = (*hit)->GetUncertainty().Y();
+        vals(posY) = (*h)->GetPosition().Y();
+        sigs(posY) = (*h)->GetUncertainty().Y();
 
-      values(idxZ) = (*hit)->GetPosition().Z();
-      sigmas(idxZ) = (*hit)->GetUncertainty().Z();
+        vals(posZ) = (*h)->GetPosition().Z();
+        sigs(posZ) = (*h)->GetUncertainty().Z();
 
-      values(idxT) = (*hit)->GetTime();
-      sigmas(idxT) = (*hit)->GetTimeUncertainty();
+        vals(posT) = (*h)->GetTime();
+        sigs(posT) = (*h)->GetTimeUncertainty();
 
-      for (int i = 0; i < dim; ++i) {
-        stateValues(i) += values(i) / (sigmas(i) * sigmas(i));
-        stateNorms(i) += 1 / (sigmas(i) * sigmas(i));
-      }
+        for (int i=0; i<dim; ++i) {
+            stateValues(i) += vals(i)/(sigs(i)*sigs(i));
+            stateNorms(i) += 1/(sigs(i)*sigs(i));
+        }
     }
 
-    for (int i = 0; i < dim; ++i) {
-      if (stateNorms(i) > 0)
-        stateValues(i) /= stateNorms(i);
+    stateNorms(eDep) = 1.0;
+    for (int i=0; i<dim; ++i) {
+        if (stateNorms(i) > 0) stateValues(i) /= stateNorms(i);
     }
 
     // Estimate the covariance of cluster state values.
     TMatrixTSym<double> stateCov(dim);
     // This counts the weight for each bin of the covariance.
-    TMatrixTSym<double> stateWeights(dim);
-    // This counts the weight squared for each bin of the covariance.
-    TMatrixTSym<double> stateWeights2(dim);
+    TMatrixTSym<double> weights(dim);
+    // This counts the number of degrees of freedom contributing to each bin.
+    TMatrixTSym<double> dof(dim);
+    for (Cube::HitSelection::const_iterator h = beg;
+         h != end;
+         ++h) {
+        vals(eDep) = (*h)->GetCharge() - stateValues(eDep);
+        sigs(eDep) = std::sqrt((*h)->GetCharge());
+        rms(eDep) = 0.0;
 
-    for (auto hit = begin; hit != end; ++hit) {
-      values(idxE) = (*hit)->GetCharge() - stateValues(idxE);
-      // The charge deposit is assumed to follow Poisson statistics
-      sigmas(idxE) = std::sqrt((*hit)->GetCharge());
-      // Treat the charge as known with infinite precision
+        vals(posX) = (*h)->GetPosition().X() - stateValues(posX);
+        sigs(posX) = (*h)->GetUncertainty().X();
+        rms(posX) = (*h)->GetSize().X();
 
-      values(idxX) = (*hit)->GetPosition().X() - stateValues(idxX);
-      sigmas(idxX) = (*hit)->GetUncertainty().X();
+        vals(posY) = (*h)->GetPosition().Y() - stateValues(posY);
+        sigs(posY) = (*h)->GetUncertainty().Y();
+        rms(posY) = (*h)->GetSize().Y();
 
-      values(idxY) = (*hit)->GetPosition().Y() - stateValues(idxY);
-      sigmas(idxY) = (*hit)->GetUncertainty().Y();
+        vals(posZ) = (*h)->GetPosition().Z() - stateValues(posZ);
+        sigs(posZ) = (*h)->GetUncertainty().Z();
+        rms(posZ) = (*h)->GetSize().Z();
 
-      values(idxZ) = (*hit)->GetPosition().Z() - stateValues(idxZ);
-      sigmas(idxZ) = (*hit)->GetUncertainty().Z();
+        vals(posT) = (*h)->GetTime() - stateValues(posT);
+        sigs(posT) = (*h)->GetTimeUncertainty();
+        rms(posT) = (*h)->GetTimeUncertainty();
 
-      values(idxT) = (*hit)->GetTime() - stateValues(idxT);
-      sigmas(idxT) = (*hit)->GetTimeUncertainty();
-
-      for (int row = 0; row < dim; ++row) {
-        for (int col = row; col < dim; ++col) {
-          double weight = 1.0 / (sigmas(row) * sigmas(col));
-          stateCov(row, col) += weight * values(row) * values(col);
-          stateWeights(row, col) += weight;
-          stateWeights2(row, col) += std::pow(weight, 2);
+        for (int row = 0; row<dim; ++row) {
+            for (int col = row; col<dim; ++col) {
+                double weight = 1.0/(sigs(row)*sigs(col));
+                stateCov(row,col) += weight*vals(row)*vals(col);
+                weights(row,col) += weight;
+                double degrees
+                    = 4*rms(row)*rms(col)/(12*sigs(row)*sigs(col));
+                if (row == posT && col == posT) degrees = 1.0;
+                dof(row,col) += degrees;
+            }
         }
-      }
     }
 
-    // Turn the "stateCov" variable into the sample covariance
-    for (int row = 0; row < dim; ++row) {
-      for (int col = row; col < dim; ++col) {
-        if (row == idxE || col == idxE) {
-          stateCov(row, col) = 0.;
-        } else {
-          stateCov(row, col) *= stateWeights(row, col) /
-                                (std::pow(stateWeights(row, col), 2) - stateWeights2(row, col));
+    // Turn the "stateCov" variable into the RMS.
+    for (int row = 0; row<dim; ++row) {
+        for (int col = row; col<dim; ++col) {
+            if (weights(row,col)>0) stateCov(row,col) /= weights(row,col);
+            else stateCov(row,col) = 0.0;
+            stateCov(col,row) = stateCov(row,col);
         }
-        if (col != row)
-          stateCov(col, row) = stateCov(row, col);
-      }
+    }
+
+    // Turn the RMS into a covariance of the mean (This is almost a repeat of
+    // turning the value into an RMS.
+    for (int row = 0; row<dim; ++row) {
+        for (int col = row; col<dim; ++col) {
+            if (dof(row,col)>0.9) stateCov(row,col) /= std::sqrt(dof(row,col));
+            else if (row==col) stateCov(row,col) = Cube::CorrValues::kFreeValue;
+            else stateCov(row,col) = 0.0;
+            stateCov(col,row) = stateCov(row,col);
+        }
+    }
+
+    // Add the correction for finite size of the hits.
+    TVectorT<double> hitWeights(dim);
+    for (Cube::HitSelection::const_iterator h = beg;
+         h != end;
+         ++h) {
+        sigs(eDep) = std::sqrt((*h)->GetCharge());
+        sigs(posX) = (*h)->GetUncertainty().X();
+        sigs(posY) = (*h)->GetUncertainty().Y();
+        sigs(posZ) = (*h)->GetUncertainty().Z();
+        sigs(posT) = (*h)->GetTimeUncertainty();
+
+        for (int idx = 0; idx<dim; ++idx) {
+            double weight = 1.0/(sigs(idx)*sigs(idx));
+            hitWeights(idx) += weight;
+        }
+    }
+
+    for (int idx = 0; idx<dim; ++idx) {
+        if (hitWeights(idx)<1E-8) continue;
+        stateCov(idx,idx) += 1.0/hitWeights(idx);
     }
 
     // Fix the variance of the deposited energy.  This assumes it's Poisson
     // distributed.
-    stateCov(idxE, idxE) = stateValues(idxE);
+    stateCov(eDep,eDep) = stateValues(eDep);
 
     // Set the state value and covariance.
-    for (int row = 0; row < dim; ++row) {
-      state->SetValue(row, stateValues(row));
-      for (int col = 0; col < dim; ++col) {
-        state->SetCovarianceValue(row, col, stateCov(row, col));
-        state->SetCovarianceValue(col, row, stateCov(row, col));
-      }
+    for (int row=0; row<dim; ++row) {
+        state->SetValue(row,stateValues(row));
+        for (int col=0; col<dim; ++col) {
+            state->SetCovarianceValue(row,col,stateCov(row,col));
+            state->SetCovarianceValue(col,row,stateCov(row,col));
+        }
     }
 
     // Find the moments of the cluster.  This could be done as part of the
@@ -265,12 +302,12 @@ void Cube::ReconCluster::UpdateFromHits() {
     // going on.
     TMatrixTSym<double> moments(3);
     TMatrixTSym<double> chargeSum(3);
-    TVector3 center(state->GetValue(idxX),
-                    state->GetValue(idxY),
-                    state->GetValue(idxZ));
+    TVector3 center(state->GetValue(posX),
+                    state->GetValue(posY),
+                    state->GetValue(posZ));
 
     // Calculate the charge weighted "sum of squared differences".
-    for (Cube::HitSelection::const_iterator h = begin;
+    for (Cube::HitSelection::const_iterator h = beg;
          h != end;
          ++h) {
         TVector3 diff = (*h)->GetPosition() - center;


### PR DESCRIPTION
Dear Clark,
this is Giorgio Pintaudi from Yokohama National University.

first of all, thank you from the bottom of my heart for letting me use this repository as a source of inspiration for the WAGASCI-BabyMIND reconstruction framework. I am in the process of adapting many parts of this very rich codebase to our experiment requirements. 

This is by far the most beautifully designed piece of software that I had the luck to deal with until now. And the only one where the object-oriented paradigm is expressed to its fullest potential. It is a very rare, almost unique, experience to open a piece of software written by a Physicists and see beauty and order. I absolutely adore your detailed comments, thanks to which I was able in a couple of days to start understanding and modifying the codebase (whereas it took me months to achieve the same for some other packages that I had to refactor).

With this pull request, I would like to draw your attention to a little piece of code, that I think I have improved (or spoiled depending if my calculations are correct or not). The algorithm itself is fine but I have some trouble making sense of the math behind it. In any case, the improvement is very very marginal so do not take it too seriously.

It is the piece of code that calculated the **covariance matrix of all the parameters of a single cluster** (`Cube::ReconCluster`). There are mainly two points that I think can be improved. 

1. First, in the existing code some corrections due to finite size of the hits are applied to the covariance matrix. I think that the finite size of the hits is already taken care of when calculating the sigma using the sqrt(12) rule. Even assuming that the finite size of the hits must be accounted for, the code is just basically dividing the covariance for the sqrt(n) where n is the number of hits. I think that this leads to underestimating the covariance.
2. Second, I have found [here](https://stats.stackexchange.com/questions/47325/bias-correction-in-weighted-variance) a slightly different formula for the weighted covariance (formula C) that I think is more correct in our scenario.

More details on the actual calculation are attached as a PDF. Sorry for the hand-written document. From page 1 to 4 I reproduce the current calculation. On page 5 is my proposal. As a bonus, the calculation is much simpler. 
[Cluster covariance.pdf](https://github.com/ClarkMcGrew/CubeRecon/files/5475999/Cluster.covariance.pdf)

This is the covariance matrix (of a 2D cluster where X coordinate is set to 0) produced by the old code:
```
State fields: X Y Z Time EDeposit 
Weighted mean +- variance:
         X　: 0.0000 +- 221.4475
         Y　: 324.6344 +- 26.8413
         Z　: 28.8708 +- 46.1529
      Time　: 1.0768 +- 0.5781
  EDeposit　: 72.2000 +- 8.4971
Correlation matrix:
                     X         Y         Z      Time  EDeposit
           X         1      negl      negl      negl      negl
           Y      negl         1      -1.6      -0.9      negl
           Z      negl      -1.6         1       1.6      negl
        Time      negl      -0.9       1.6         1      negl
    EDeposit      negl      negl      negl      negl         1
Position Cov:      4.9e+04           0           0
                         0     7.2e+02      -2e+03
                         0      -2e+03     2.1e+03
Moments:           2.6e+05           0           0
                         0     3.8e+03    -6.1e+03
                         0    -6.1e+03     1.1e+04
```
This is the same covariance matrix produced by my code:
```
State fields: X Y Z Time EDeposit 
Weighted mean +- variance:
         X　: 0.0000 +- 221.4475
         Y　: 324.6344 +- 26.8413
         Z　: 28.8708 +- 46.1529
      Time　: 1.0768 +- 0.9072
  EDeposit　: 72.2000 +- 8.4971
Correlation matrix:
                     X         Y         Z      Time  EDeposit
           X         1      negl      negl      negl      negl
           Y      negl         1      -3.3      -1.3      negl
           Z      negl      -3.3         1       2.2      negl
        Time      negl      -1.3       2.2         1      negl
    EDeposit      negl      negl      negl      negl         1
Position Cov:      4.9e+04           0           0
                         0     7.2e+02    -4.1e+03
                         0    -4.1e+03     2.1e+03
Moments:           2.6e+05           0           0
                         0     3.8e+03    -6.1e+03
                         0    -6.1e+03     1.1e+04
``` 

As you can see the difference is not huge and one can argue that such a small change in the cluster covariance matrix makes little impact on the overall reconstruction efficiency anyway. If you think this is wrong or not necessary feel free to ignore this pull request.

Giorgio

